### PR TITLE
Ajouter Nous Toutes et Electronic Tales dans les associations qu'on soutient

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -17,6 +17,8 @@ Cependant, vous pouvez soutenir ces autres associations qui nous tiennent à coe
 - [Lallab](https://www.lallab.fr/)
 - [La place des Grenouilles](https://lapdg.fr/)
 - [Le Refuge](https://le-refuge.org/)
+- [NousToutes](https://www.helloasso.com/associations/noustoutes)
+- [Electronic Tales](https://fr.ulule.com/micro-bootcamps/)
 
 ## Email
 


### PR DESCRIPTION
Ces deux associations cherchent actuellement des dons : 
- NousToutes pour la manifestation du 25/11 
- Electronic Tales pour l'organisation de microbootcamps à destination de personnes minorisé.e.s dans la tech

Je me disais qu'on pourrait les ajouter à la liste ?